### PR TITLE
More registry matters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,18 @@ VECTORFIGURES =
 # Additional files to distribute (e.g., CSS, schema files, examples...)
 AUX_FILES = VOEvent-v2.1.xsd VOEventRegExt-v2.0.xsd resrec-sample.vor
 
-include ivoatex/Makefile
-
 -include ivoatex/Makefile
 
 ivoatex/Makefile:
 	@echo "*** ivoatex submodule not found.  Initialising submodules."
 	@echo
 	git submodule update --init
+
+resrec-sample.vor:
+	curl "http://dc.g-vo.org/oai.xml?verb=GetRecord&metadataPrefix=ivo_vor&identifier=ivo://org.gavo.dc/std/gcn-swift-uvot/swift"\
+		|  xmlstarlet sel -B -Nri:http://www.ivoa.net/xml/RegistryInterface/v1.0\
+			-t -c //ri:Resource \
+		| xmlstarlet fo > resrec-sample.vor
 
 test:
 	@echo "No tests defined yet"

--- a/VOEvent.tex
+++ b/VOEvent.tex
@@ -214,7 +214,7 @@ VOEvents inherit much of the structure and semantics of \textbf{VOTable}
 \citep{2018ivoa.spec.0527P} scheme for semantics of quantities and the VOUnits
 standard \citep{2023ivoa.spec.1215G}. VOEvent takes space-time coordinates from
 the \textbf{STC} \citep{2007ivoa.spec.1030R}, and it uses the URI semantics of the
-IVOA \textbf{Vocabulary} 1.0 \citep{2009ivoa.spec.1007G} effort. IVOA 
+IVOA \textbf{Vocabulary} 1.0 \citep{2009ivoa.spec.1007G} effort. IVOA
 \textbf{Identifiers} \citep{2016ivoa.spec.0523D} are used for events and their
 parent streams and servers, and both these latter are described by IVOA
 \textbf{Resource Metadata} \citep{2007ivoa.spec.0302H} and stored in the VO
@@ -691,7 +691,7 @@ elements. There is then a 1-to-1 correspondence between them for each row.
 
 The Table can contain \verb|<Description>| and \verb|<Reference>| elements to add
 documentation; the \verb|<Field>| elements can also contain these. Thus
-the \verb|<Table>| can contain, in order, an optional \verb|<Description>| and 
+the \verb|<Table>| can contain, in order, an optional \verb|<Description>| and
 \verb|<Reference>|, then a sequence of one or more \verb|<Field>| elements, then a
 \verb|<Data>| element. The \verb|<Field>| element can also contain
 optional \verb|<Description>| and \verb|<Reference>| and nothing else. The \verb|<Data>| element
@@ -722,7 +722,7 @@ significance to subscribing clients.
 
 \noindent \textbf{3.3.3.4} \xmlel{unit}\label{sec:3.3.3.4} --- The unit for
 interpreting the values as given in the \verb|<TD>| table cells. See \S4.4 of
-\citep{2019ivoa.spec.1021O}, which relies on \citep{2023ivoa.spec.1215G}. 
+\citep{2019ivoa.spec.1021O}, which relies on \citep{2023ivoa.spec.1215G}.
 
 \noindent \textbf{3.3.3.5} \xmlel{ucd}\label{sec:3.3.3.5} --- A UCD
 \citep{2018ivoa.spec.0527P} expression characterizing the nature of the data in
@@ -1282,7 +1282,7 @@ Splitting, merging or retracting a VOEvent should typically be accompanied by a
 An attempt is made to retract the sighting of Tycho's supernova:
 \begin{lstlisting}
 <Citations>
-    <EventIVORN 
+    <EventIVORN
         cite="retraction">ivo://uraniborg.hven#1572-11-11/0001</EventIVORN>
     <Description>Oops!</Description>
 </Citations>
@@ -1388,7 +1388,7 @@ uniqueness is maintained using the Registry.
 \end{compactitem}
 
 It is recommended to register VOEvent streams using
-\xmlel{vs:CatalogService} (or, if the stream is only accessible through
+\xmlel{vs:CatalogSer\-vice} (or, if the stream is only accessible through
 third-party services, \xmlel{vs:Catalog\-Resource})
 resources, as these allow service operators
 to attach rich metadata like the originating facility and instrument, and
@@ -1396,8 +1396,7 @@ possibly extra stream metadata in a tableset.  However, this
 specification does not constrain the resource type.
 
 A public event stream MUST define a capability with standard id of
-\nolinkurl{ivo://ivoa.net/std/VOEvent}.
-
+\nolinkurl{ivo://ivoa.net/std/voevent}.
 Note that path parts in IVOA identifiers are case-insensitive, and hence
 when comparing ivoids, clients must ignore case.
 
@@ -1405,13 +1404,19 @@ This specification does not constrain the type of the capability, but as
 of this version, it is recommended to use plain \xmlel{vr:capability}
 elements (i.e., not have \xmlel{xsi:type} attributes).
 
+When multiple VOEvent streams share their VOResource metadata (curation,
+summary title and description, coverage, etc), they should be defined as
+multiple VOEvent capabilities of the same VOResource record; these
+capabilities should then come with human-readable description of the
+stream's contents.
+
 Zero or more endpoints publishing the event stream are declared within
 this capability element using \xmlel{vr:interface} elements with their
 \xmlel{role} attributes set to \verb|std|; such standard interfaces MUST
 be of type \xmlel{voe:Stream\-Endpoint} and then by the schema MUST have
 a \xmlel{standardID} attribute, the value of which SHOULD reference one
 of the keys in this standard's registry record,
-\nolinkurl{ivo://ivoa.net/std/VOEvent}.
+\nolinkurl{ivo://ivoa.net/std/voevent}.
 
 As of this writing, these keys include:
 
@@ -1718,7 +1723,7 @@ previously an \xmlel{idValues} type, now it is a simple \xmlel{xs:string} type.
 This allows to include Solar and Planetary frames without modifying the
 schema. The \xmlel{idValues} type and its references (in \xmlel{AstroCoordSystem}
 and \xmlel{coord\_system\_id}) have been removed. The \xmlel{AstroCoordSystem} can
-be fully described with a \xmlel{TimeFrame} and a \xmlel{SpaceFrame}, see 
+be fully described with a \xmlel{TimeFrame} and a \xmlel{SpaceFrame}, see
 \citet{2007ivoa.spec.1030R}.
 \item Annotations in \xmlel{AstroCoords/Time} and \xmlel{AstroCoords/Position2D}
 have been included in the schema (according to STC-1.33).

--- a/VOEvent.tex
+++ b/VOEvent.tex
@@ -1425,7 +1425,12 @@ As of this writing, these keys include:
   Protocol \citep{2017ivoa.spec.0320S}
 \item \verb|acc-xmpp| The endpoint uses an informal method based on
     	XMPP (jabber).
-\item \verb|acc-kafka| The endpoint uses Apache Kafka \citep{kafka}.
+\item \verb|acc-kafka| The endpoint uses Apache Kafka \citep{kafka}.  In
+VOResource, the access URLs for Kafka enpoints use a VO-custom URI
+prefix x-kafka.  The authority part in these URIs is the kafka host. In
+the query part of the URI, give any extra parameters, in particular
+\emph{topic}.
+
 \item \verb|acc-proprietary| The endpoint is usable by some
   method not (yet) mentioned in the VOEvent standard's registry record.
 \end{compactitem}
@@ -1445,9 +1450,9 @@ provider, perhaps to ensure high availability:
     <accessURL>http://example.org/events/vtp</accessURL>
   </interface>
   <interface xsi:type="voe:StreamEndpoint" role="std"
-      standardID="ivo://ivoa.net/std/voevent#acc-vtp">
-    <accessURL>http://example.org/events/kafka</accessURL>
-    <accessURL>http://bigshot.com/streams/example-voe</accessURL>
+      standardID="ivo://ivoa.net/std/voevent#acc-kafka">
+    <accessURL>x-kafka://example.org?topic=sample-stream</accessURL>
+    <mirrorURL>x-kafka://bigshot.com?topic=sample-stream</mirrorURL>
   </interface>
 </capability>
 \end{lstlisting}

--- a/resrec-sample.vor
+++ b/resrec-sample.vor
@@ -1,80 +1,93 @@
-<ri:Resource
-    xmlns:voe="http://www.ivoa.net/xml/VOEventRegExt/v2"
-    xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
-    xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0"
-    xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    created="2020-10-28T15:11:00Z"
-    status="active"
-    updated="2020-10-28T15:11:00Z"
-    xsi:type="vs:CatalogService">
-    <title>Meteor Shower prediction</title>
-    <shortName>meteor_showers</shortName>
-    <identifier>ivo://vopdc.obspm/imcce/meteorshower/event</identifier>
-    <curation>
-        <publisher ivo-id="ivo://vopdc.obspm/imcce"
-          >Paris Astronomical Data Centre - IMCCE</publisher>
-        <creator>
-            <name>Jeremy Vaubaillon</name>
-        </creator>
-        <date role="updated">2019-03-22T15:50:42</date>
-        <contact>
-            <name>PADC support team</name>
-            <address>77 av. Denfert Rochereau, 75014 Paris, FRANCE</address>
-            <email>vo.paris@observatoiredeparis.psl.eu</email>
-            <telephone>0033140512082</telephone>
-        </contact>
-    </curation>
-    <content>
-        <subject>Comet</subject>
-        <subject>Simulation</subject>
-        <description>
-            This is an ephemeris of meteor showers occurring on solar
-            system planets, produced by simulating the ejection of
-            meteoroids from the sunlit hemisphere of cometary nuclei, typically
-            from 0 to 3 au, followed by the propagation of orbits of meteoroids
-            in the Solar System, taking into account the gravitation of the
-            Sun, the 8 planets, Pluto, and the Moon, as well as the radiation
-            pressure and the Poynting-Robertson drag. Note that asteroid parent
-            bodies were considered as active (i.e. comet-like bodies) even if
-            they are not active today. The showers are predicted when a planet
-            enters a large enough set of meteoroids, at a distance less than
-            typically 0.01 au. See Vaubaillon J., Colas F., Jorda L. 2005 A new
-            method to predict meteor showers. I. Description of the model,
-            Astronomy and Astrophysics, Volume 439/2 p.751-760, as well as:
-            Vaubaillon J. 2017 A confidence index for forecasting of meteor
-            showers, Planetary and Space Science, Volume 143 p.78-82
-        </description>
-        <source format="bibcode">2017P%26SS..143...78V</source>
-        <referenceURL>
-          http://voparis-tap-voevent.obspm.fr/tableinfo/meteor_showers.epn_core
-        </referenceURL>
-        <type>Other</type>
-        <contentLevel>Research</contentLevel>
-        <relationship>
-            <!-- TAP service containing/archiving all previous
-              events produced by this stream -->
-            <relationshipType>IsSourceOf</relationshipType>
-            <relatedResource ivo-id="ivo://vopdc.obspm/imcce/meteorshower/epn"
-              >Meteor Shower prediction EPN-TAP service</relatedResource>
-        </relationship>
-    </content>
-    <capability standardID="ivo://ivoa.net/std/VOEvent">
-        <!-- TODO: figure out if this needs a declaration like
-          "This is VOEvent 2 in XML serialisation" – or if that's
-          implied in something else we're saying here -->
-        <interface role="std" xsi:type="voe:StreamEndpoint"
-          standardID="ivo://ivoa.net/std/VOEvent#acc-vtp">
-            <accessURL>x-vtp://voparis-voevent-psws.obspm.fr:8099</accessURL>
-        </interface>
-    </capability>
-    <facility>IMCCE</facility>
-    <coverage>
-        <waveband>Radio</waveband>
-        <waveband>Optical</waveband>
-        <waveband>Infrared</waveband>
-    </coverage>
-</ri:Resource>
+<?xml version="1.0"?>
+<ri:Resource xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0" xmlns:voe="http://www.ivoa.net/xml/VOEventRegExt/v2" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" created="2025-06-04T14:00:00Z" status="active" updated="2025-10-02T08:32:12Z" version="1.2" xsi:type="vs:DataService">
+  <title>GCN VOEvent Streams From Swift-UVOT</title>
+  <shortName>swift-UVOT VOEv</shortName>
+  <identifier>ivo://org.gavo.dc/std/gcn-swift-uvot/swift</identifier>
+  <curation>
+    <publisher>GCN</publisher>
+    <creator>
+      <name>The Swift Team</name>
+    </creator>
+    <date role="updated">2035-01-01T00:00:00</date>
+    <contact>
+      <name>The Swift Team</name>
+      <email>support@gcn.nasa.gov</email>
+    </contact>
+  </curation>
+  <content>
+    <subject>gamma-ray-astronomy</subject>
+    <subject>gamma-ray-bursts</subject>
+    <subject>time-domain-astronomy</subject>
+    <description> VOEvent alerts produced from transient detections resulting from
+observations with the NASA Neil Gehrels Swift Observatory and the
+Ultraviolet Optical Telescope. Events should be reported within tens
+to of seconds to hours; expect about 3 events per week, where most
+events correspond to a gamma ray bursts, but other transients may
+occur.
 
-<!-- vim:et:sw=2
--->
+Streams giving localizations for gamma ray transients with follow-up
+characterization in the ultraviolet/optical including localization and
+images with their ground-processed data. The sequence includes a
+postage stamp image (SWIFT_UVOT_DBURST, SWIFT_UVOT_DBURST_PROC),
+finding charts (SWIFT_UVOT_FCHART,SWIFT_UVOT_FCHART_PROC), and
+localization acquired (SWIFT_UVOT_POS) or not acquired
+(SWIFT_UVOT_POS_NACK).</description>
+    <source format="bibcode">2004ApJ...611.1005G</source>
+    <referenceURL>http://dc.g-vo.org/std/gcn-swift-uvot/swift/info</referenceURL>
+    <contentLevel>Research</contentLevel>
+  </content>
+  <rights>public</rights>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events including a postage stamp image.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_DBURST</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events including a postage stamp image, after ground
+processing.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_DBURST_PROC</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events including a finding chart.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_FCHART</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events including a finding chart, after ground
+processing.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_FCHART_PROC</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events where positions have been acquired.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_POS</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/voevent">
+    <description>Fermi UV followup events where positions have not been acquired.</description>
+    <interface role="std" standardID="ivo://ivoa.net/std/voevent#acc-kafka" xsi:type="voe:StreamEndpoint">
+      <accessURL use="full">x-kafka://kafka.gcn.nasa.gov?topic=gcn.classic.voevent.SWIFT_UVOT_POS_NACK</accessURL>
+    </interface>
+  </capability>
+  <capability>
+    <description>A browser-based archive of the events recorded.</description>
+    <interface xsi:type="vr:WebBrowser">
+      <accessURL use="full">https://gcn.gsfc.nasa.gov/swift_grbs.html</accessURL>
+    </interface>
+  </capability>
+  <facility>Swift</facility>
+  <instrument>UVOT</instrument>
+  <coverage>
+    <spatial>0/0-11</spatial>
+    <temporal>53329 64328</temporal>
+    <spectral>3.056070549e-19 1.168497563e-18</spectral>
+    <footprint ivo-id="ivo://ivoa.net/std/moc">http://dc.g-vo.org/std/gcn-swift-uvot/swift/coverage</footprint>
+    <waveband>Ultraviolet/Optical</waveband>
+  </coverage>
+</ri:Resource>


### PR DESCRIPTION
This PR clearly states that mulitple streams in a single resource (e.g., unprocessed and processed, or with or without finding charts) must come in different capabilities.

This also contains the kafka clarification from PR #26; I think this is at least not grossly insane.